### PR TITLE
Priyam/day dividers

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -4325,9 +4325,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.70.2",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.2.tgz",
-      "integrity": "sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==",
+      "version": "2.70.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.3.tgz",
+      "integrity": "sha512-UDvEYuZqAMbfB/oXIoqKvbKcb7YczK5zYrzmsGV1zRJk03jntwp8dXiYoIJotxAndsKvcPFtx9H1GRSKFdSHgg==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",

--- a/site/src/components/course-planner/schedule/Schedule.svelte
+++ b/site/src/components/course-planner/schedule/Schedule.svelte
@@ -152,17 +152,29 @@ Copyright (C) 2026 Andrew Cupps
   <div
     bind:this={elt}
     style="height:calc(100% - 1.5rem)"
-    class="relative grid grow pl-9 2xl:pl-11"
+    class="relative grid grow pl-9 [--gutter:2.25rem] 2xl:pl-11 2xl:[--gutter:2.75rem]"
     class:grid-cols-5={schedule.other.length == 0}
     class:grid-cols-6={schedule.other.length > 0}
   >
     <!-- Background lines for the schedule -->
     <!-- format-check exempt 2 -->
     <div
-      style="width: {schedule.other.length == 0 ? 'calc(100% - 8px)' : '83.3%'};"
-      class="absolute bottom-0 left-1 top-6 z-0"
+      style="width: {schedule.other.length == 0 ? '100%' : 'calc(var(--gutter) + (100% - var(--gutter)) * 5 / 6)'};"
+      class="absolute bottom-0 left-0 top-6 z-0"
     >
       <ScheduleBackground bind:earliest={earliestClassStart} bind:latest={latestClassEnd} bind:h={bgHeight} />
+    </div>
+
+    <!-- Vertical lines delimiting each day column -->
+    <div
+      style="height: {bgHeight}px;"
+      class="border-border top-9.5 pointer-events-none absolute left-9 z-0 grid w-[calc(100%-2.25rem)] border-r 2xl:left-11 2xl:w-[calc(100%-2.75rem)]"
+      class:grid-cols-5={schedule.other.length == 0}
+      class:grid-cols-6={schedule.other.length > 0}
+    >
+      {#each Array.from({ length: schedule.other.length > 0 ? 6 : 5 }, (_, i) => i) as columnIndex (columnIndex)}
+        <div class="border-border border-l"></div>
+      {/each}
     </div>
 
     <!-- ClassTimes by day -->

--- a/site/src/components/course-planner/schedule/Schedule.svelte
+++ b/site/src/components/course-planner/schedule/Schedule.svelte
@@ -168,12 +168,12 @@ Copyright (C) 2026 Andrew Cupps
     <!-- Vertical lines delimiting each day column -->
     <div
       style="height: {bgHeight}px;"
-      class="border-border top-9.5 pointer-events-none absolute left-9 z-0 grid w-[calc(100%-2.25rem)] border-r 2xl:left-11 2xl:w-[calc(100%-2.75rem)]"
+      class="border-border top-9.5 pointer-events-none absolute left-9 z-0 grid w-[calc(100%-2.25rem)] 2xl:left-11 2xl:w-[calc(100%-2.75rem)]"
       class:grid-cols-5={schedule.other.length == 0}
       class:grid-cols-6={schedule.other.length > 0}
     >
       {#each Array.from({ length: schedule.other.length > 0 ? 6 : 5 }, (_, i) => i) as columnIndex (columnIndex)}
-        <div class="border-border border-l"></div>
+        <div class="border-border border-l" class:border-r={columnIndex === 4 && schedule.other.length == 0}></div>
       {/each}
     </div>
 

--- a/site/src/components/course-planner/schedule/TimeLine.svelte
+++ b/site/src/components/course-planner/schedule/TimeLine.svelte
@@ -15,7 +15,7 @@ Copyright (C) 2026 Andrew Cupps
 
 <div style="top: {position * 100}%" class="absolute h-7 w-full">
   <div
-    style="left: -4px; top: 50%; transform: translateY(-50%);"
+    style="left: 0; top: 50%; transform: translateY(-50%);"
     class="w-8.5 absolute text-right text-xs font-light 2xl:w-10 2xl:text-sm"
   >
     {number}


### PR DESCRIPTION
Added vertical day dividers between day columns on the schedule, completing the time line grid.

Pictures for reference (with and without a class in the "other" column)
<img width="1341" height="800" alt="image" src="https://github.com/user-attachments/assets/ea407c81-5206-4cd6-8113-4bf3ba647ecb" />
<img width="1343" height="811" alt="image" src="https://github.com/user-attachments/assets/ea5f771d-d51b-40c7-a308-f8651edc349e" />
